### PR TITLE
Actually load DeviceGetClockInfo

### DIFF
--- a/src/nvml.c
+++ b/src/nvml.c
@@ -1331,6 +1331,7 @@ static BOOL load_nvml(void)
     TRY_LOAD_FUNCPTR(nvmlDeviceGetBrand);
     TRY_LOAD_FUNCPTR(nvmlDeviceGetBridgeChipInfo);
     TRY_LOAD_FUNCPTR(nvmlDeviceGetClock);
+    TRY_LOAD_FUNCPTR(nvmlDeviceGetClockInfo);
     TRY_LOAD_FUNCPTR(nvmlDeviceGetComputeMode);
     TRY_LOAD_FUNCPTR(nvmlDeviceGetCount);
     TRY_LOAD_FUNCPTR(nvmlDeviceGetCount_v2);


### PR DESCRIPTION
Hopefully just a miss when you added 6f8e8505bca5a75d961d2c54764620de4de48262